### PR TITLE
Feature/fish dataset 2021

### DIFF
--- a/cellbrowser_tools/bin/build_release.py
+++ b/cellbrowser_tools/bin/build_release.py
@@ -58,7 +58,7 @@ def process_fov_row(group, args, prefs):
     name = dataHandoffUtils.get_fov_name_from_row(rows[0])
     log.info(f"STARTING FOV {name}")
     try:
-        createJobsFromCSV.do_image(args, prefs, rows)
+        createJobsFromCSV.do_image(args.cluster, args.run, prefs, rows)
     except Exception as e:
         log.error("=============================================")
         if args.debug:
@@ -98,7 +98,7 @@ def submit_fov_rows(args, prefs, groups):
     jobdata_list = []
     log.info("PREPARING " + str(len(groups)) + " JOBS")
     for index, rows in enumerate(groups):
-        jobdata = createJobsFromCSV.do_image(args, prefs, rows)
+        jobdata = createJobsFromCSV.do_image(args.cluster, args.run, prefs, rows)
         jobdata_list.append(jobdata)
 
     log.info("SUBMITTING " + str(len(groups)) + " JOBS")
@@ -377,7 +377,7 @@ def main():
             p.cluster = True
             build_images_async(p, prefs)
         elif p.step == BuildStep.VALIDATE:
-            groups = dataHandoffUtils.uncache_dataset(prefs)
+            groups = dataHandoffUtils.uncache_dataset(prefs.get("out_dir"))
             validate_fov_rows(groups, p, prefs)
             log.info("validate_fov_rows done")
         elif p.step == BuildStep.FEATUREDATA:

--- a/cellbrowser_tools/bin/build_release.py
+++ b/cellbrowser_tools/bin/build_release.py
@@ -142,7 +142,6 @@ def submit_done(prefs, prefspath, job_ids):
 
 
 def build_feature_data(prefs):
-    # validateProcessedImages.build_feature_data(prefs, groups)
     validateProcessedImages.build_cfe_dataset_2020(prefs)
     return True
 

--- a/cellbrowser_tools/bin/make_downloader_manifest.py
+++ b/cellbrowser_tools/bin/make_downloader_manifest.py
@@ -1,0 +1,202 @@
+import argparse
+import csv
+import logging
+import os
+import sys
+import traceback
+
+from datetime import datetime
+from logging import FileHandler, StreamHandler, Formatter
+from cellbrowser_tools.dataHandoffUtils import (
+    QueryOptions,
+    ActionOptions,
+    OutputPaths,
+    get_data_groups2,
+)
+from cellbrowser_tools.dataset_constants import DataField, FILE_LIST_FILENAME
+
+
+class Args(argparse.Namespace):
+    def __init__(self):
+        super().__init__()
+        self.output_dir = "./output/make_images"
+        self.input_manifest = ""
+        self.env = "stg"
+        self.debug = False
+        self.cell_lines = None
+        self.plates = None
+        self.fovids = None
+        self.start_date = None
+        self.end_date = None
+        self.do_crop = False
+        #
+        self.__parse()
+
+    def __parse(self):
+        p = argparse.ArgumentParser(
+            prog="Make downloader manifest",
+            description="Generates csv file with input data for downloader dataset",
+        )
+        p.add_argument(
+            "--input_manifest",
+            type=str,
+            help="csv file containing dataset source data",
+            required=True,
+        )
+        p.add_argument(
+            "--output_dir",
+            type=str,
+            help="directory where outputs should be saved (can be isilon)",
+            default="./output/make_downloader_manifest",
+            required=False,
+        )
+        p.add_argument(
+            "--env",
+            choices=["dev", "stg", "prod"],
+            help="AICS Labkey / Data platform environment to use (default is 'stg')",
+            default="stg",
+            required=False,
+        )
+        p.add_argument(
+            "--debug",
+            help="Enable debug mode",
+            default=False,
+            required=False,
+            action="store_true",
+        )
+        actions_group = p.add_argument_group(
+            "Actions",
+            "Combine any of the following flags to determine the image outputs",
+        )
+        actions_group.add_argument(
+            "--do_crop",
+            help="Generate cropped child images",
+            default=False,
+            required=False,
+            action="store_true",
+        )
+        filter_group = p.add_argument_group(
+            "Filter options",
+            "Combine any of the following options to filter FOVs that will be processed.",
+        )
+        filter_group.add_argument(
+            "--cell_lines",
+            nargs="+",
+            help="Array of Cell-lines to run. E.g. --cell_lines 'AICS-11' 'AICS-7' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--plates",
+            nargs="+",
+            help="Array of plates to run. E.g. --plates '3500003813' '3500003642' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--fovids",
+            nargs="+",
+            help="Array of fovids to run. E.g. --fovs '123' '6' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--start_date",
+            type=str,
+            help="Filter on FOVs created on or after a specific date (inclusive). Date format YYYY-MM-DD. Ex: '2020-12-01' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--end_date",
+            type=str,
+            help="Filter on FOVs created on or before a specific date (inclusive). Date format YYYY-MM-DD. Ex: '2020-12-01' ",
+            default=None,
+            required=False,
+        )
+        p.parse_args(namespace=self)
+
+
+###############################################################################
+
+
+def configure_logging(debug: bool):
+    f = Formatter(fmt="[%(asctime)s][%(levelname)s] %(message)s")
+    streamHandler = StreamHandler()
+    streamHandler.setFormatter(f)
+    fileHandler = FileHandler(
+        filename=f"make_images_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.log",
+        mode="w",
+    )
+    fileHandler.setFormatter(f)
+    log = logging.getLogger()  # root logger
+    log.handlers = [streamHandler, fileHandler]  # overwrite handlers
+    log.setLevel(logging.DEBUG if debug else logging.INFO)
+
+
+def main():
+    args = Args()
+    debug = args.debug
+    configure_logging(debug)
+    log = logging.getLogger(__name__)
+
+    try:
+        log.info("Start make_images")
+        log.info(f"Environment: {args.env}")
+        log.info(args)
+
+        query_options = QueryOptions(
+            args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
+        )
+        action_options = ActionOptions(
+            args.do_thumbnails, args.do_atlases, args.do_crop
+        )
+
+        # setup directories
+        output_paths = OutputPaths(args.output_dir)
+
+        # gather data set
+        groups = get_data_groups2(args.input_manifest, query_options, args.output_dir)
+
+        # TODO log the command line args
+        # statusdir = output_paths.status_dir
+        # prefspath = Path(f"{statusdir}/prefs.json").expanduser()
+        # shutil.copyfile(p.prefs, prefspath)
+
+        outrows = []
+        for index, rows in enumerate(groups):
+            # use row 0 as the "full field" row
+            fovrow = rows[0]
+            outrows.append(
+                {
+                    "file_id": str(fovrow[DataField.FOVId]),
+                    "file_name": fovrow[DataField.SourceFilename],
+                    "read_path": fovrow[DataField.SourceReadPath],
+                    "file_size": os.path.getsize(fovrow[DataField.SourceReadPath]),
+                    # "other_keys": "other_values"
+                }
+            )
+        keys = outrows[0].keys()
+        with open(
+            os.path.join(output_paths.out_dir, FILE_LIST_FILENAME), "w", newline="",
+        ) as output_file:
+            dict_writer = csv.DictWriter(output_file, keys)
+            dict_writer.writeheader()
+            dict_writer.writerows(outrows)
+
+        log.info("All done!")
+
+    except Exception as e:
+        log.error("=============================================")
+        log.error("\n\n" + traceback.format_exc())
+        log.error("=============================================")
+        log.error("\n\n" + str(e) + "\n")
+        log.error("=============================================")
+        sys.exit(1)
+
+
+###############################################################################
+# Allow caller to directly run this module (usually in development scenarios)
+
+if __name__ == "__main__":
+    main()

--- a/cellbrowser_tools/bin/make_downloader_manifest.py
+++ b/cellbrowser_tools/bin/make_downloader_manifest.py
@@ -12,6 +12,7 @@ from cellbrowser_tools.dataHandoffUtils import (
     ActionOptions,
     OutputPaths,
     get_data_groups2,
+    normalize_path,
 )
 from cellbrowser_tools.dataset_constants import DataField, FILE_LIST_FILENAME
 
@@ -146,10 +147,11 @@ def main():
         log.info(args)
 
         query_options = QueryOptions(
-            args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
-        )
-        action_options = ActionOptions(
-            args.do_thumbnails, args.do_atlases, args.do_crop
+            args.fovids,
+            args.plates,
+            args.cell_lines,
+            args.start_date,
+            args.end_date,
         )
 
         # setup directories
@@ -172,13 +174,17 @@ def main():
                     "file_id": str(fovrow[DataField.FOVId]),
                     "file_name": fovrow[DataField.SourceFilename],
                     "read_path": fovrow[DataField.SourceReadPath],
-                    "file_size": os.path.getsize(fovrow[DataField.SourceReadPath]),
+                    "file_size": os.path.getsize(
+                        normalize_path(fovrow[DataField.SourceReadPath])
+                    ),
                     # "other_keys": "other_values"
                 }
             )
         keys = outrows[0].keys()
         with open(
-            os.path.join(output_paths.out_dir, FILE_LIST_FILENAME), "w", newline="",
+            os.path.join(output_paths.out_dir, FILE_LIST_FILENAME),
+            "w",
+            newline="",
         ) as output_file:
             dict_writer = csv.DictWriter(output_file, keys)
             dict_writer.writeheader()

--- a/cellbrowser_tools/bin/make_images.py
+++ b/cellbrowser_tools/bin/make_images.py
@@ -5,7 +5,7 @@ import traceback
 
 from datetime import datetime
 from logging import FileHandler, StreamHandler, Formatter
-from cellbrowser_tools.dataHandoffUtils import QueryOptions
+from cellbrowser_tools.dataHandoffUtils import QueryOptions, ActionOptions
 from cellbrowser_tools import build_images
 
 
@@ -28,7 +28,7 @@ class Args(argparse.Namespace):
     def __parse(self):
         p = argparse.ArgumentParser(
             prog="Make images",
-            description="Generates volume-viewer files for a series of images with or without segmentations.",
+            description="Generates volume-viewer files for a series of images",
         )
         p.add_argument(
             "--input_manifest",
@@ -57,6 +57,31 @@ class Args(argparse.Namespace):
             required=False,
             action="store_true",
         )
+        actions_group = p.add_argument_group(
+            "Actions",
+            "Combine any of the following flags to determine the image outputs",
+        )
+        actions_group.add_argument(
+            "--do_thumbnails",
+            help="Generate png thumbnail images",
+            default=True,
+            required=False,
+            action="store_true",
+        )
+        actions_group.add_argument(
+            "--do_atlases",
+            help="Generate volume-viewer atlas files",
+            default=True,
+            required=False,
+            action="store_true",
+        )
+        actions_group.add_argument(
+            "--do_crop",
+            help="Generate cropped child images",
+            default=True,
+            required=False,
+            action="store_true",
+        )
         filter_group = p.add_argument_group(
             "Filter options",
             "Combine any of the following options to filter FOVs that will be processed.",
@@ -64,21 +89,21 @@ class Args(argparse.Namespace):
         filter_group.add_argument(
             "--cell_lines",
             nargs="+",
-            help="Array of Cell-lines to run segmentations on. E.g. --cell_lines 'AICS-11' 'AICS-7' ",
+            help="Array of Cell-lines to run. E.g. --cell_lines 'AICS-11' 'AICS-7' ",
             default=None,
             required=False,
         )
         filter_group.add_argument(
             "--plates",
             nargs="+",
-            help="Array of plates to run segmentations on. E.g. --plates '3500003813' '3500003642' ",
+            help="Array of plates to run. E.g. --plates '3500003813' '3500003642' ",
             default=None,
             required=False,
         )
         filter_group.add_argument(
             "--fovids",
             nargs="+",
-            help="Array of fovids to run segmentations on. E.g. --fovs '123' '6' ",
+            help="Array of fovids to run. E.g. --fovs '123' '6' ",
             default=None,
             required=False,
         )
@@ -136,14 +161,15 @@ def main():
         log.info(args)
 
         query_options = QueryOptions(
-            args.fovids,
-            args.plates,
-            args.cell_lines,
-            args.start_date,
-            args.end_date,
+            args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
         )
+        action_options = ActionOptions(args.do_thumbnais, args.do_atlases, args.do_crop)
         build_images.build_images(
-            args.input_manifest, args.output_dir, args.distributed, query_options
+            args.input_manifest,
+            args.output_dir,
+            args.distributed,
+            query_options,
+            action_options,
         )
 
     except Exception as e:

--- a/cellbrowser_tools/bin/make_images.py
+++ b/cellbrowser_tools/bin/make_images.py
@@ -1,0 +1,152 @@
+import argparse
+import logging
+import sys
+import traceback
+
+from datetime import datetime
+from logging import FileHandler, StreamHandler, Formatter
+from cellbrowser_tools.dataHandoffUtils import QueryOptions
+import cellbrowser_tools.build_images
+
+
+class Args(argparse.Namespace):
+    def __init__(self):
+        super().__init__()
+        self.output_dir = "./output/make_images"
+        self.input_manifest = ""
+        self.env = "stg"
+        self.distributed = False
+        self.debug = False
+        self.cell_lines = None
+        self.plates = None
+        self.fovids = None
+        self.start_date = None
+        self.end_date = None
+        #
+        self.__parse()
+
+    def __parse(self):
+        p = argparse.ArgumentParser(
+            prog="Make images",
+            description="Generates volume-viewer files for a series of images with or without segmentations.",
+        )
+        p.add_argument(
+            "--output_dir",
+            type=str,
+            help="directory where outputs should be saved (can be isilon)",
+            default="./output/make_images",
+            required=False,
+        )
+        p.add_argument(
+            "--env",
+            choices=["dev", "stg", "prod"],
+            help="AICS Labkey / Data platform environment to use (default is 'stg')",
+            default="stg",
+            required=False,
+        )
+        p.add_argument(
+            "--debug",
+            help="Enable debug mode",
+            default=False,
+            required=False,
+            action="store_true",
+        )
+        filter_group = p.add_argument_group(
+            "Filter options",
+            "Combine any of the following options to filter FOVs that will be processed.",
+        )
+        filter_group.add_argument(
+            "--cell_lines",
+            nargs="+",
+            help="Array of Cell-lines to run segmentations on. E.g. --cell_lines 'AICS-11' 'AICS-7' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--plates",
+            nargs="+",
+            help="Array of plates to run segmentations on. E.g. --plates '3500003813' '3500003642' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--fovids",
+            nargs="+",
+            help="Array of fovids to run segmentations on. E.g. --fovs '123' '6' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--start_date",
+            type=str,
+            help="Filter on FOVs created on or after a specific date (inclusive). Date format YYYY-MM-DD. Ex: '2020-12-01' ",
+            default=None,
+            required=False,
+        )
+        filter_group.add_argument(
+            "--end_date",
+            type=str,
+            help="Filter on FOVs created on or before a specific date (inclusive). Date format YYYY-MM-DD. Ex: '2020-12-01' ",
+            default=None,
+            required=False,
+        )
+        distributed = p.add_argument_group("distributed", "Distributed run options")
+        distributed.add_argument(
+            "--distributed",
+            help="Run in distributed mode (default is False)",
+            default=False,
+            required=False,
+            action="store_true",
+        )
+        p.parse_args(namespace=self)
+
+
+###############################################################################
+
+
+def configure_logging(debug: bool):
+    f = Formatter(fmt="[%(asctime)s][%(levelname)s] %(message)s")
+    streamHandler = StreamHandler()
+    streamHandler.setFormatter(f)
+    fileHandler = FileHandler(
+        filename=f"make_images_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.log",
+        mode="w",
+    )
+    fileHandler.setFormatter(f)
+    log = logging.getLogger()  # root logger
+    log.handlers = [streamHandler, fileHandler]  # overwrite handlers
+    log.setLevel(logging.DEBUG if debug else logging.INFO)
+
+
+def main():
+    args = Args()
+    debug = args.debug
+    configure_logging(debug)
+    log = logging.getLogger(__name__)
+
+    try:
+        log.info("Start make_images")
+        log.info(f"Environment: {args.env}")
+        log.info(args)
+
+        query_options = QueryOptions(
+            args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
+        )
+        build_images.build_images(
+            args.input_manifest, args.output_dir, args.distributed, query_options
+        )
+
+    except Exception as e:
+        log.error("=============================================")
+        log.error("\n\n" + traceback.format_exc())
+        log.error("=============================================")
+        log.error("\n\n" + str(e) + "\n")
+        log.error("=============================================")
+        sys.exit(1)
+
+
+###############################################################################
+# Allow caller to directly run this module (usually in development scenarios)
+
+if __name__ == "__main__":
+    main()

--- a/cellbrowser_tools/bin/make_images.py
+++ b/cellbrowser_tools/bin/make_images.py
@@ -163,7 +163,9 @@ def main():
         query_options = QueryOptions(
             args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
         )
-        action_options = ActionOptions(args.do_thumbnais, args.do_atlases, args.do_crop)
+        action_options = ActionOptions(
+            args.do_thumbnails, args.do_atlases, args.do_crop
+        )
         build_images.build_images(
             args.input_manifest,
             args.output_dir,

--- a/cellbrowser_tools/bin/make_images.py
+++ b/cellbrowser_tools/bin/make_images.py
@@ -31,6 +31,12 @@ class Args(argparse.Namespace):
             description="Generates volume-viewer files for a series of images with or without segmentations.",
         )
         p.add_argument(
+            "--input_manifest",
+            type=str,
+            help="csv file containing dataset source data",
+            required=True,
+        )
+        p.add_argument(
             "--output_dir",
             type=str,
             help="directory where outputs should be saved (can be isilon)",
@@ -130,9 +136,13 @@ def main():
         log.info(args)
 
         query_options = QueryOptions(
-            args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
+            args.fovids,
+            args.plates,
+            args.cell_lines,
+            args.start_date,
+            args.end_date,
         )
-        build_images(
+        build_images.build_images(
             args.input_manifest, args.output_dir, args.distributed, query_options
         )
 

--- a/cellbrowser_tools/bin/make_images.py
+++ b/cellbrowser_tools/bin/make_images.py
@@ -64,7 +64,7 @@ class Args(argparse.Namespace):
         actions_group.add_argument(
             "--do_thumbnails",
             help="Generate png thumbnail images",
-            default=True,
+            default=False,
             required=False,
             action="store_true",
         )
@@ -78,7 +78,7 @@ class Args(argparse.Namespace):
         actions_group.add_argument(
             "--do_crop",
             help="Generate cropped child images",
-            default=True,
+            default=False,
             required=False,
             action="store_true",
         )

--- a/cellbrowser_tools/bin/make_images.py
+++ b/cellbrowser_tools/bin/make_images.py
@@ -6,7 +6,7 @@ import traceback
 from datetime import datetime
 from logging import FileHandler, StreamHandler, Formatter
 from cellbrowser_tools.dataHandoffUtils import QueryOptions
-import cellbrowser_tools.build_images
+from cellbrowser_tools import build_images
 
 
 class Args(argparse.Namespace):
@@ -132,7 +132,7 @@ def main():
         query_options = QueryOptions(
             args.fovids, args.plates, args.cell_lines, args.start_date, args.end_date,
         )
-        build_images.build_images(
+        build_images(
             args.input_manifest, args.output_dir, args.distributed, query_options
         )
 

--- a/cellbrowser_tools/build_images.py
+++ b/cellbrowser_tools/build_images.py
@@ -1,0 +1,82 @@
+import logging
+import os
+from pathlib import Path
+import shutil
+
+import createJobsFromCSV
+import dataHandoffUtils
+import jobScheduler
+
+
+log = logging.getLogger(__name__)
+
+
+def submit_done(prefs, prefspath, job_ids):
+    command = f"build_release {prefspath} --step done"
+    deps = job_ids
+    new_job_ids = jobScheduler.submit_one(command, prefs, name="done", deps=deps)
+    return new_job_ids
+
+
+def submit_fov_rows(args, prefs, groups):
+    # gather cluster commands and submit in batch
+    jobdata_list = []
+    log.info("PREPARING " + str(len(groups)) + " JOBS")
+    for index, rows in enumerate(groups):
+        jobdata = createJobsFromCSV.do_image(args, prefs, rows)
+        jobdata_list.append(jobdata)
+
+    log.info("SUBMITTING " + str(len(groups)) + " JOBS")
+    job_ids = jobScheduler.submit_batch(jobdata_list, prefs, name="fovs")
+    return job_ids
+
+
+def get_data_groups(
+    input_manifest: os.PathLike,
+    query_options: dataHandoffUtils.QueryOptions,
+    prefs,
+    n=0,
+):
+    data = dataHandoffUtils.collect_csv_data_rows(
+        input_manifest, fovids=query_options.fovids, cell_lines=query_options.cell_lines
+    )
+    log.info("Number of total cell rows: " + str(len(data)))
+    # group by fov id
+    data_grouped = data.groupby("FOVId")
+    total_jobs = len(data_grouped)
+    log.info("Number of total FOVs: " + str(total_jobs))
+    # log.info('ABOUT TO CREATE ' + str(total_jobs) + ' JOBS')
+    groups = []
+    for index, (fovid, group) in enumerate(data_grouped):
+        groups.append(group.to_dict(orient="records"))
+        # only the first n FOVs (one group per FOV)
+        if n > 0 and index >= n - 1:
+            break
+
+    log.info("Converted groups to lists of dicts")
+
+    # make dataset available as a file for later runs
+    dataHandoffUtils.cache_dataset(prefs, groups)
+
+    return groups
+
+
+def build_images(
+    input_manifest: os.PathLike,
+    output_dir: os.PathLike,
+    distributed: bool,
+    query_options: dataHandoffUtils.QueryOptions,
+):
+    # gather data set
+    groups = dataHandoffUtils.get_data_groups(prefs, p.n)
+
+    # copy the prefs file to a location where it can be found for all steps.
+    statusdir = prefs["out_status"]
+    prefspath = Path(f"{statusdir}/prefs.json").expanduser()
+    shutil.copyfile(p.prefs, prefspath)
+
+    # use SLURM sbatch submission to schedule all the steps
+    # each step will run build_release.py with a step id
+    job_ids = submit_fov_rows(p, prefs, groups)
+    job_ids = submit_done(prefs, prefspath, job_ids)
+    log.info("All Jobs Submitted!")

--- a/cellbrowser_tools/build_images.py
+++ b/cellbrowser_tools/build_images.py
@@ -2,9 +2,9 @@ from cellbrowser_tools.dataHandoffUtils import OutputPaths
 import logging
 import os
 
-import createJobsFromCSV
-import dataHandoffUtils
-import jobScheduler
+from . import createJobsFromCSV
+from . import dataHandoffUtils
+from . import jobScheduler
 
 
 log = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ def submit_fov_rows(args, prefs, groups):
     jobdata_list = []
     log.info("PREPARING " + str(len(groups)) + " JOBS")
     for index, rows in enumerate(groups):
-        jobdata = createJobsFromCSV.do_image(args.cluster, args.run, prefs, rows)
+        jobdata = createJobsFromCSV.do_image(args["cluster"], args["run"], prefs, rows)
         jobdata_list.append(jobdata)
 
     log.info("SUBMITTING " + str(len(groups)) + " JOBS")
@@ -69,7 +69,7 @@ def build_images(
     output_paths = OutputPaths(output_dir)
 
     # gather data set
-    groups = get_data_groups(input_manifest, query_options)
+    groups = get_data_groups(input_manifest, query_options, output_dir)
 
     # TODO log the command line args
     # statusdir = output_paths.status_dir

--- a/cellbrowser_tools/build_images.py
+++ b/cellbrowser_tools/build_images.py
@@ -22,7 +22,15 @@ def submit_fov_rows(args, prefs, groups):
     jobdata_list = []
     log.info("PREPARING " + str(len(groups)) + " JOBS")
     for index, rows in enumerate(groups):
-        jobdata = createJobsFromCSV.do_image(args["cluster"], args["run"], prefs, rows)
+        jobdata = createJobsFromCSV.do_image(
+            args["cluster"],
+            args["run"],
+            prefs,
+            rows,
+            do_thumbnails=False,  # TODO get this from args
+            do_crop=False,  # TODO get this from args
+            save_raw=False,
+        )
         jobdata_list.append(jobdata)
 
     log.info("SUBMITTING " + str(len(groups)) + " JOBS")
@@ -79,7 +87,9 @@ def build_images(
     # use SLURM sbatch submission to schedule all the steps
     # each step will run build_release.py with a step id
     job_ids = submit_fov_rows(
-        {"cluster": distributed, "run": not distributed}, output_paths.__dict__, groups
+        {"cluster": distributed, "run": not distributed},
+        output_paths.__dict__,
+        groups,
     )
     job_ids = submit_done(output_paths.__dict__, job_ids)
     log.info("All Jobs Submitted!")

--- a/cellbrowser_tools/cellJob.py
+++ b/cellbrowser_tools/cellJob.py
@@ -9,3 +9,5 @@ class CellJob(object):
         self.cbrImageLocation = ""
         # root output directory for volume-viewer texture atlases
         self.cbrTextureAtlasLocation = ""
+        # whether or not to build thumbnail images in addition to 3d volumes
+        self.do_thumbnails = True

--- a/cellbrowser_tools/cellJob.py
+++ b/cellbrowser_tools/cellJob.py
@@ -11,3 +11,7 @@ class CellJob(object):
         self.cbrTextureAtlasLocation = ""
         # whether or not to build thumbnail images in addition to 3d volumes
         self.do_thumbnails = True
+        # whether or not to process cropped single cell images
+        self.do_crop = True
+        # whether or not to save ome-tiff files with reordered channels
+        self.save_raw = True

--- a/cellbrowser_tools/createJobsFromCSV.py
+++ b/cellbrowser_tools/createJobsFromCSV.py
@@ -66,7 +66,7 @@ def make_json(jobname, info, prefs):
     return f"processImageWithSegmentation {jsonname}"
 
 
-def do_image(args, prefs, rows):
+def do_image(make_job: bool, run_now: bool, prefs, rows):
     # use row 0 as the "full field" row
     row = rows[0]
 
@@ -101,9 +101,9 @@ def do_image(args, prefs, rows):
     os.makedirs(info.cbrImageLocation, exist_ok=True)
     os.makedirs(info.cbrThumbnailLocation, exist_ok=True)
 
-    if args.run:
+    if run_now:
         do_main_image_with_celljob(info)
-    elif args.cluster:
+    elif make_job:
         # TODO: set arg to copy each indiv file to another output
         return make_json(jobname, info, prefs)
 
@@ -142,7 +142,7 @@ def process_images(args, prefs):
                 + fovid
             )
 
-            jobdata = do_image(args, prefs, rows)
+            jobdata = do_image(args.cluster, args.run, prefs, rows)
             jobdata_list.append(jobdata)
 
         print("SUBMITTING " + str(total_jobs) + " JOBS")
@@ -160,7 +160,7 @@ def process_images(args, prefs):
                 + " : "
                 + fovid
             )
-            do_image(args, prefs, rows)
+            do_image(args.cluster, args.run, prefs, rows)
 
 
 def is_process_images_done(args):

--- a/cellbrowser_tools/createJobsFromCSV.py
+++ b/cellbrowser_tools/createJobsFromCSV.py
@@ -6,7 +6,7 @@ import sys
 from . import cellJob
 from . import dataHandoffUtils as lkutils
 from . import jobScheduler
-from .dataset_constants import DataField
+from .dataset_constants import DataField, SLURM_SCRIPTS_DIR
 from .fov_processing import do_main_image_with_celljob
 
 # cbrImageLocation path to cellbrowser images
@@ -53,7 +53,7 @@ def make_json(jobname, info, prefs):
     cell_job_postfix = jobname
     cellline = info.cells[0]["CellLine"]
     current_dir = os.path.join(
-        prefs["out_status"], prefs["script_dir"]
+        prefs["out_status"], SLURM_SCRIPTS_DIR
     )  # os.path.join(os.getcwd(), outdir)
     dest_dir = os.path.join(current_dir, cellline)
 

--- a/cellbrowser_tools/createJobsFromCSV.py
+++ b/cellbrowser_tools/createJobsFromCSV.py
@@ -66,7 +66,15 @@ def make_json(jobname, info, prefs):
     return f"processImageWithSegmentation {jsonname}"
 
 
-def do_image(make_job: bool, run_now: bool, prefs, rows):
+def do_image(
+    make_job: bool,
+    run_now: bool,
+    prefs,
+    rows,
+    do_thumbnails=True,
+    do_crop=True,
+    save_raw=True,
+):
     # use row 0 as the "full field" row
     row = rows[0]
 
@@ -80,7 +88,9 @@ def do_image(make_job: bool, run_now: bool, prefs, rows):
 
     info = cellJob.CellJob(rows)
 
-    info.do_thumbnails = prefs["do_thumbnails"]
+    info.do_thumbnails = do_thumbnails
+    info.do_crop = do_crop
+    info.save_raw = save_raw
 
     # drop images here
     info.cbrDataRoot = prefs["images_dir"]

--- a/cellbrowser_tools/createJobsFromCSV.py
+++ b/cellbrowser_tools/createJobsFromCSV.py
@@ -53,7 +53,7 @@ def make_json(jobname, info, prefs):
     cell_job_postfix = jobname
     cellline = info.cells[0]["CellLine"]
     current_dir = os.path.join(
-        prefs["out_status"], SLURM_SCRIPTS_DIR
+        prefs["status_dir"], SLURM_SCRIPTS_DIR
     )  # os.path.join(os.getcwd(), outdir)
     dest_dir = os.path.join(current_dir, cellline)
 

--- a/cellbrowser_tools/createJobsFromCSV.py
+++ b/cellbrowser_tools/createJobsFromCSV.py
@@ -80,6 +80,8 @@ def do_image(make_job: bool, run_now: bool, prefs, rows):
 
     info = cellJob.CellJob(rows)
 
+    info.do_thumbnails = prefs["do_thumbnails"]
+
     # drop images here
     info.cbrDataRoot = prefs["images_dir"]
     # drop thumbnails here

--- a/cellbrowser_tools/createJobsFromCSV.py
+++ b/cellbrowser_tools/createJobsFromCSV.py
@@ -80,10 +80,8 @@ def do_image(
 
     jobname = lkutils.get_fov_name_from_row(row)
 
-    # dataset is assumed to be in source_data = ....dataset_cellnuc_seg_curated/[DATASET]/spreadsheets_dir/sheet_name
-
     aicscelllineid = str(row[DataField.CellLine])
-    celllinename = aicscelllineid  # 'AICS-' + str(aicscelllineid)
+    celllinename = aicscelllineid
     subdir = celllinename
 
     info = cellJob.CellJob(rows)

--- a/cellbrowser_tools/dataHandoffUtils.py
+++ b/cellbrowser_tools/dataHandoffUtils.py
@@ -220,7 +220,11 @@ FULL_FEATURES_DATA = "//allen/aics/assay-dev/MicroscopyOtherData/Viana/forDan/cf
 
 
 def collect_csv_data_rows(
-    csvpath=FULL_DATASET, fovids=None, cell_lines=None, raw_only=False, max_rows=None,
+    csvpath=FULL_DATASET,
+    fovids=None,
+    cell_lines=None,
+    raw_only=False,
+    max_rows=None,
 ):
     log.info("REQUESTING DATA HANDOFF")
     df_data_handoff = pd.read_csv(csvpath)
@@ -400,7 +404,12 @@ def get_csv_features(path: str = FULL_FEATURES_DATA):
 
 def cache_dataset(out_dir: os.PathLike, groups):
     with open(
-        os.path.join(out_dir, dataset_constants.DATASET_JSON_FILENAME), "w"
+        os.path.join(
+            out_dir,
+            dataset_constants.STATUS_DIR,
+            dataset_constants.DATASET_JSON_FILENAME,
+        ),
+        "w",
     ) as savefile:
         json.dump(groups, savefile)
     log.info("Saved dataset to json")
@@ -409,7 +418,12 @@ def cache_dataset(out_dir: os.PathLike, groups):
 def uncache_dataset(out_dir: os.PathLike):
     groups = []
     with open(
-        os.path.join(out_dir, dataset_constants.DATASET_JSON_FILENAME), "r"
+        os.path.join(
+            out_dir,
+            dataset_constants.STATUS_DIR,
+            dataset_constants.DATASET_JSON_FILENAME,
+        ),
+        "r",
     ) as savefile:
         groups = json.load(savefile)
     return groups
@@ -441,7 +455,9 @@ def get_data_groups(prefs, n=0):
 
 
 def get_data_groups2(
-    input_manifest: os.PathLike, query_options: QueryOptions, out_dir: os.PathLike,
+    input_manifest: os.PathLike,
+    query_options: QueryOptions,
+    out_dir: os.PathLike,
 ):
     data = collect_csv_data_rows(
         input_manifest, fovids=query_options.fovids, cell_lines=query_options.cell_lines

--- a/cellbrowser_tools/dataHandoffUtils.py
+++ b/cellbrowser_tools/dataHandoffUtils.py
@@ -1,5 +1,5 @@
 from . import dataset_constants
-from .dataset_constants import DataField
+from .dataset_constants import DataField, SLURM_SCRIPTS_DIR, SLURM_OUTPUT_DIR, SLURM_ERROR_DIR
 import json
 from lkaccess import LabKey
 import lkaccess.contexts
@@ -80,12 +80,12 @@ def setup_prefs(json_path):
     prefs["atlas_dir"] = atlas_dir
 
     prefs["sbatch_output"] = os.path.join(
-        prefs["out_status"], prefs["script_dir"], prefs["job_prefs"]["output"]
+        prefs["out_status"], SLURM_SCRIPTS_DIR, SLURM_OUTPUT_DIR
     )
     os.makedirs(os.path.dirname(prefs["sbatch_output"]), exist_ok=True)
 
     prefs["sbatch_error"] = os.path.join(
-        prefs["out_status"], prefs["script_dir"], prefs["job_prefs"]["error"]
+        prefs["out_status"], SLURM_SCRIPTS_DIR, SLURM_ERROR_DIR
     )
     os.makedirs(os.path.dirname(prefs["sbatch_error"]), exist_ok=True)
 

--- a/cellbrowser_tools/dataHandoffUtils.py
+++ b/cellbrowser_tools/dataHandoffUtils.py
@@ -25,6 +25,19 @@ logging.basicConfig(
 )
 
 
+class ActionOptions:
+    """
+    Options for set of files to generate
+    """
+
+    def __init__(
+        self, do_thumbnails: bool = True, do_atlases: bool = True, do_crop: bool = True
+    ):
+        self.do_thumbnails = do_thumbnails
+        self.do_atlases = do_atlases
+        self.do_crop = do_crop
+
+
 class QueryOptions:
     """
     Filters / options for the querying of images in a data input manifest csv
@@ -207,11 +220,7 @@ FULL_FEATURES_DATA = "//allen/aics/assay-dev/MicroscopyOtherData/Viana/forDan/cf
 
 
 def collect_csv_data_rows(
-    csvpath=FULL_DATASET,
-    fovids=None,
-    cell_lines=None,
-    raw_only=False,
-    max_rows=None,
+    csvpath=FULL_DATASET, fovids=None, cell_lines=None, raw_only=False, max_rows=None,
 ):
     log.info("REQUESTING DATA HANDOFF")
     df_data_handoff = pd.read_csv(csvpath)

--- a/cellbrowser_tools/dataHandoffUtils.py
+++ b/cellbrowser_tools/dataHandoffUtils.py
@@ -163,7 +163,7 @@ class OutputPaths:
         )
         self.save_log_path = os.path.join(self.status_dir, DATA_LOG_NAME)
 
-    def _create_dir(d: os.PathLike, name: str):
+    def _create_dir(self, d: os.PathLike):
         if not os.path.exists(d):
             os.makedirs(d)
         return d
@@ -207,7 +207,11 @@ FULL_FEATURES_DATA = "//allen/aics/assay-dev/MicroscopyOtherData/Viana/forDan/cf
 
 
 def collect_csv_data_rows(
-    csvpath=FULL_DATASET, fovids=None, cell_lines=None, raw_only=False, max_rows=None,
+    csvpath=FULL_DATASET,
+    fovids=None,
+    cell_lines=None,
+    raw_only=False,
+    max_rows=None,
 ):
     log.info("REQUESTING DATA HANDOFF")
     df_data_handoff = pd.read_csv(csvpath)
@@ -265,6 +269,8 @@ def collect_csv_data_rows(
             return "M4/M5"
         elif mid == 6:
             return "Mitosis"
+        elif mid is None:
+            return ""
         else:
             raise ValueError("Unexpected value for MitoticStateId")
 

--- a/cellbrowser_tools/dataHandoffUtils.py
+++ b/cellbrowser_tools/dataHandoffUtils.py
@@ -175,11 +175,11 @@ def get_cellline_name_from_row(row):
 
 # cellline must be 'AICS-#'
 def get_fov_name(fovid, cellline):
-    return f"{cellline}_{fovid}"
+    return f"{fovid}"
 
 
 def get_cell_name(cellid, fovid, cellline):
-    return f"{cellline}_{fovid}_{cellid}"
+    return f"{get_fov_name(fovid, cellline)}_{cellid}"
 
 
 def get_fov_name_from_row(row):

--- a/cellbrowser_tools/dataHandoffUtils.py
+++ b/cellbrowser_tools/dataHandoffUtils.py
@@ -440,6 +440,33 @@ def get_data_groups(prefs, n=0):
     return groups
 
 
+def get_data_groups2(
+    input_manifest: os.PathLike, query_options: QueryOptions, out_dir: os.PathLike,
+):
+    data = collect_csv_data_rows(
+        input_manifest, fovids=query_options.fovids, cell_lines=query_options.cell_lines
+    )
+    log.info("Number of total cell rows: " + str(len(data)))
+    # group by fov id
+    data_grouped = data.groupby("FOVId")
+    total_jobs = len(data_grouped)
+    log.info("Number of total FOVs: " + str(total_jobs))
+    # log.info('ABOUT TO CREATE ' + str(total_jobs) + ' JOBS')
+    groups = []
+    for index, (fovid, group) in enumerate(data_grouped):
+        groups.append(group.to_dict(orient="records"))
+        # only the first n FOVs (one group per FOV)
+        if query_options.first_n > 0 and index >= query_options.first_n - 1:
+            break
+
+    log.info("Converted groups to lists of dicts")
+
+    # make dataset available as a file for later runs
+    cache_dataset(out_dir, groups)
+
+    return groups
+
+
 if __name__ == "__main__":
     print(sys.argv)
     collect_data_rows()

--- a/cellbrowser_tools/dataset_constants.py
+++ b/cellbrowser_tools/dataset_constants.py
@@ -92,3 +92,6 @@ class DataField(str, Enum):
 class AugmentedDataField(str, Enum):
     IsMitotic = "IsMitotic"
     MitoticState = "MitoticState"
+    ChannelNumber561 = "ChannelNumber561"
+    # special case for FISH dataset
+    GenePair = "gene-pair"

--- a/cellbrowser_tools/dataset_constants.py
+++ b/cellbrowser_tools/dataset_constants.py
@@ -12,6 +12,7 @@ DATASET_JSON_FILENAME = "dataset.json"
 ERROR_FOVS_FILENAME = "errorFovs.txt"
 CHANNEL_NAMES_FILENAME = "allChannelNames.txt"
 
+STATUS_DIR = "processing"
 SLURM_SCRIPTS_DIR = "scripts_slurm"
 SLURM_OUTPUT_DIR = "out/"
 SLURM_ERROR_DIR = "err/"

--- a/cellbrowser_tools/dataset_constants.py
+++ b/cellbrowser_tools/dataset_constants.py
@@ -12,6 +12,10 @@ DATASET_JSON_FILENAME = "dataset.json"
 ERROR_FOVS_FILENAME = "errorFovs.txt"
 CHANNEL_NAMES_FILENAME = "allChannelNames.txt"
 
+SLURM_SCRIPTS_DIR = "scripts_slurm"
+SLURM_OUTPUT_DIR = "out/"
+SLURM_ERROR_DIR = "err/"
+
 
 # the expected column names returned from labkey
 class DataField(str, Enum):

--- a/cellbrowser_tools/dataset_constants.py
+++ b/cellbrowser_tools/dataset_constants.py
@@ -94,4 +94,4 @@ class AugmentedDataField(str, Enum):
     MitoticState = "MitoticState"
     ChannelNumber561 = "ChannelNumber561"
     # special case for FISH dataset
-    GenePair = "gene-pair"
+    GenePair = "gene_pair"

--- a/cellbrowser_tools/dataset_constants.py
+++ b/cellbrowser_tools/dataset_constants.py
@@ -15,6 +15,7 @@ CHANNEL_NAMES_FILENAME = "allChannelNames.txt"
 SLURM_SCRIPTS_DIR = "scripts_slurm"
 SLURM_OUTPUT_DIR = "out/"
 SLURM_ERROR_DIR = "err/"
+DATA_LOG_NAME = "data_jobs_out.csv"
 
 
 # the expected column names returned from labkey

--- a/cellbrowser_tools/fov_processing.py
+++ b/cellbrowser_tools/fov_processing.py
@@ -62,10 +62,7 @@ def _clean_ome_xml_for_known_issues(xml: str) -> str:
     # This is from OMEXML object just having invalid reference
     for known_invalid_ref in KNOWN_INVALID_OME_XSD_REFERENCES:
         if known_invalid_ref in xml:
-            xml = xml.replace(
-                known_invalid_ref,
-                REPLACEMENT_OME_XSD_REFERENCE,
-            )
+            xml = xml.replace(known_invalid_ref, REPLACEMENT_OME_XSD_REFERENCE,)
             metadata_changes.append(
                 f"Replaced '{known_invalid_ref}' with "
                 f"'{REPLACEMENT_OME_XSD_REFERENCE}'."
@@ -274,11 +271,7 @@ def _clean_ome_xml_for_known_issues(xml: str) -> str:
         ET.register_namespace("", f"http://{REPLACEMENT_OME_XSD_REFERENCE}")
 
         # Write out cleaned XML to string
-        xml = ET.tostring(
-            root,
-            encoding="unicode",
-            method="xml",
-        )
+        xml = ET.tostring(root, encoding="unicode", method="xml",)
 
     return xml
 
@@ -443,7 +436,7 @@ class ImageProcessor:
         # this is enough data to combine together many channels from many files
 
         # start with 4 channels for membrane, structure, nucleus and transmitted light
-        self.channel_names = ["OBS_Memb", "OBS_STRUCT", "OBS_DNA", "OBS_Trans"]
+        self.channel_names = ["Membrane", "Labeled structure", "DNA", "Bright field"]
         self.channel_colors = [
             _rgba255(128, 0, 128, 255),
             _rgba255(128, 128, 0, 255),
@@ -464,7 +457,7 @@ class ImageProcessor:
         if self.row[DataField.CellIndex].startswith("C") and self.row[
             DataField.FOVId
         ].startswith("F"):
-            self.channel_names[1] = "OBS_Alpha-actinin-2"
+            self.channel_names[1] = "Alpha-actinin-2"
 
         # special case of channel combo when "gene-pair" is present
         # TODO FIX ME
@@ -477,11 +470,11 @@ class ImageProcessor:
                     "Expected gene-pair to have two values joined by hyphen"
                 )
             self.channel_names = [
-                "OBS_Alpha-actinin-2",
-                "OBS_DNA",
-                "OBS_Trans",
-                f"OBS_{pair[0]}",
-                f"OBS_{pair[1]}",
+                "Alpha-actinin-2",
+                "DNA",
+                "Bright field",
+                f"{pair[0]}",
+                f"{pair[1]}",
             ]
             self.channel_colors = [
                 _rgba255(128, 0, 128, 255),
@@ -809,10 +802,7 @@ class ImageProcessor:
 
         log.info("generating atlas ...")
         atlas = textureAtlas.generate_texture_atlas(
-            aimage,
-            name=base,
-            max_edge=2048,
-            pack_order=None,
+            aimage, name=base, max_edge=2048, pack_order=None,
         )
         log.info("done making atlas")
         p = self.omexml.images[0].pixels
@@ -931,10 +921,7 @@ class ImageProcessor:
             # aimage_cropped.metadata = copyxml
             log.info("generating cropped atlas ...")
             atlas_cropped = textureAtlas.generate_texture_atlas(
-                aimage_cropped,
-                name=cell_name,
-                max_edge=2048,
-                pack_order=None,
+                aimage_cropped, name=cell_name, max_edge=2048, pack_order=None,
             )
             atlas_cropped.dims.pixel_size_x = pixels.physical_size_x
             atlas_cropped.dims.pixel_size_y = pixels.physical_size_y
@@ -958,13 +945,7 @@ class ImageProcessor:
         log.info("done processing cells for this fov")
 
     def _save_and_post(
-        self,
-        image,
-        thumbnail,
-        textureatlas,
-        name="",
-        omexml=None,
-        other_data=None,
+        self, image, thumbnail, textureatlas, name="", omexml=None, other_data=None,
     ):
         # physical_size = [0.065, 0.065, 0.29]
         # note these are strings here.  it's ok for xml purposes but not for any math.

--- a/cellbrowser_tools/fov_processing.py
+++ b/cellbrowser_tools/fov_processing.py
@@ -457,8 +457,8 @@ class ImageProcessor:
             int(self.row[DataField.ChannelNumberBrightfield]),
         ]
         # special case of channel combo when "gene-pair" is present
-        genepair = self.row[AugmentedDataField.GenePair]
-        if genepair:
+        genepair = self.row.get(AugmentedDataField.GenePair)
+        if genepair is not None:
             # genepair is a hyphenated split of 561 and 638 channel names
             pair = genepair.split("-")
             if len(pair) != 2:
@@ -763,7 +763,7 @@ class ImageProcessor:
 
         return m
 
-    def generate_and_save(self, do_segmented_cells=True):
+    def generate_and_save(self, do_segmented_cells=True, save_raw=True):
         base = self.file_name
 
         # indices of channels in the original image
@@ -813,7 +813,7 @@ class ImageProcessor:
         static_meta = self.generate_meta(self.omexml, self.row)
 
         self._save_and_post(
-            image=im_to_save,
+            image=im_to_save if save_raw else None,
             thumbnail=ffthumb,
             textureatlas=atlas,
             name=base,
@@ -936,7 +936,7 @@ class ImageProcessor:
             log.info("done making cropped atlas")
 
             self._save_and_post(
-                image=im_to_save,
+                image=im_to_save if save_raw else None,
                 thumbnail=thumb,
                 textureatlas=atlas_cropped,
                 name=cell_name,
@@ -1005,7 +1005,7 @@ class ImageProcessor:
 
 def do_main_image_with_celljob(info):
     processor = ImageProcessor(info)
-    processor.generate_and_save()
+    processor.generate_and_save(do_segmented_cells=info.do_crop, save_raw=info.save_raw)
 
 
 def do_main_image(fname):

--- a/cellbrowser_tools/fov_processing.py
+++ b/cellbrowser_tools/fov_processing.py
@@ -456,7 +456,18 @@ class ImageProcessor:
             int(self.row[DataField.ChannelNumber405]),
             int(self.row[DataField.ChannelNumberBrightfield]),
         ]
+
+        # special case replace OBS_STRUCT with OBS_Alpha-actinin-2
+        # if CellIndex starts with C and FOVId starts with F then we are in a special data set.
+        # gene-editing FISH chaos 2019
+        # TODO FIX ME
+        if self.row[DataField.CellIndex].startswith("C") and self.row[
+            DataField.FOVId
+        ].startswith("F"):
+            self.channel_names[1] = "OBS_Alpha-actinin-2"
+
         # special case of channel combo when "gene-pair" is present
+        # TODO FIX ME
         genepair = self.row.get(AugmentedDataField.GenePair)
         if genepair is not None:
             # genepair is a hyphenated split of 561 and 638 channel names
@@ -466,7 +477,7 @@ class ImageProcessor:
                     "Expected gene-pair to have two values joined by hyphen"
                 )
             self.channel_names = [
-                "OBS_Alpha Actinin 2",
+                "OBS_Alpha-actinin-2",
                 "OBS_DNA",
                 "OBS_Trans",
                 f"OBS_{pair[0]}",
@@ -808,7 +819,7 @@ class ImageProcessor:
         atlas.dims.pixel_size_x = p.physical_size_x
         atlas.dims.pixel_size_y = p.physical_size_y
         atlas.dims.pixel_size_z = p.physical_size_z
-        atlas.dims.channel_names = [c.name for c in p.channels]
+        atlas.dims.channel_names = [c for c in self.channel_names]
         # grab metadata for display
         static_meta = self.generate_meta(self.omexml, self.row)
 
@@ -928,7 +939,7 @@ class ImageProcessor:
             atlas_cropped.dims.pixel_size_x = pixels.physical_size_x
             atlas_cropped.dims.pixel_size_y = pixels.physical_size_y
             atlas_cropped.dims.pixel_size_z = pixels.physical_size_z
-            atlas_cropped.dims.channel_names = [c.name for c in pixels.channels]
+            atlas_cropped.dims.channel_names = [c for c in self.channel_names]
 
             static_meta_cropped = self.generate_meta(copyxml, row, cell_meta)
 

--- a/cellbrowser_tools/fov_processing.py
+++ b/cellbrowser_tools/fov_processing.py
@@ -452,46 +452,45 @@ class ImageProcessor:
         file_list = []
 
         # structure segmentation
-        if self.row[DataField.StructureSegmentationReadPath] != "":
-            struct_seg_file = utils.normalize_path(
-                self.row[DataField.StructureSegmentationReadPath]
-            )
+        readpath = self.row[DataField.StructureSegmentationReadPath]
+        if readpath != "" and readpath is not None:
+            struct_seg_file = utils.normalize_path(readpath)
             # print(struct_seg_file)
             file_list.append((struct_seg_file, 0, "SEG_STRUCT"))
             self.channel_names.append("SEG_STRUCT")
             self.channel_colors.append(_rgba255(255, 0, 0, 255))
 
         # cell segmentation
-        cell_seg_file = utils.normalize_path(
-            self.row[DataField.MembraneSegmentationReadPath]
-        )
-        # print(cell_seg_file)
-        file_list.append(
-            (
-                cell_seg_file,
-                self.row[DataField.MembraneSegmentationChannelIndex],
-                "SEG_Memb",
+        readpath = self.row[DataField.MembraneSegmentationReadPath]
+        if readpath != "" and readpath is not None:
+            cell_seg_file = utils.normalize_path(readpath)
+            # print(cell_seg_file)
+            file_list.append(
+                (
+                    cell_seg_file,
+                    self.row[DataField.MembraneSegmentationChannelIndex],
+                    "SEG_Memb",
+                )
             )
-        )
-        self.channel_names.append("SEG_Memb")
-        self.channel_colors.append(_rgba255(0, 0, 255, 255))
-        self.channels_to_mask.append(len(self.channel_names) - 1)
+            self.channel_names.append("SEG_Memb")
+            self.channel_colors.append(_rgba255(0, 0, 255, 255))
+            self.channels_to_mask.append(len(self.channel_names) - 1)
 
         # nucleus segmentation
-        nuc_seg_file = utils.normalize_path(
-            self.row[DataField.NucleusSegmentationReadPath]
-        )
-        # print(nuc_seg_file)
-        file_list.append(
-            (
-                nuc_seg_file,
-                self.row[DataField.NucleusSegmentationChannelIndex],
-                "SEG_DNA",
+        readpath = self.row[DataField.NucleusSegmentationReadPath]
+        if readpath != "" and readpath is not None:
+            nuc_seg_file = utils.normalize_path(readpath)
+            # print(nuc_seg_file)
+            file_list.append(
+                (
+                    nuc_seg_file,
+                    self.row[DataField.NucleusSegmentationChannelIndex],
+                    "SEG_DNA",
+                )
             )
-        )
-        self.channel_names.append("SEG_DNA")
-        self.channel_colors.append(_rgba255(0, 255, 0, 255))
-        self.channels_to_mask.append(len(self.channel_names) - 1)
+            self.channel_names.append("SEG_DNA")
+            self.channel_colors.append(_rgba255(0, 255, 0, 255))
+            self.channels_to_mask.append(len(self.channel_names) - 1)
 
         if self.row[DataField.MembraneContourReadPath] is None:
             self.row[DataField.MembraneContourReadPath] = self.row[
@@ -499,16 +498,20 @@ class ImageProcessor:
             ]
 
         # cell contour segmentation (good for viz in the volume viewer)
-        cell_con_file = utils.normalize_path(
-            self.row[DataField.MembraneContourReadPath]
-        )
-        # print(cell_seg_file)
-        file_list.append(
-            (cell_con_file, self.row[DataField.MembraneContourChannelIndex], "CON_Memb")
-        )
-        self.channel_names.append("CON_Memb")
-        self.channel_colors.append(_rgba255(255, 255, 0, 255))
-        self.channels_to_mask.append(len(self.channel_names) - 1)
+        readpath = self.row[DataField.MembraneContourReadPath]
+        if readpath != "" and readpath is not None:
+            cell_con_file = utils.normalize_path(readpath)
+            # print(cell_seg_file)
+            file_list.append(
+                (
+                    cell_con_file,
+                    self.row[DataField.MembraneContourChannelIndex],
+                    "CON_Memb",
+                )
+            )
+            self.channel_names.append("CON_Memb")
+            self.channel_colors.append(_rgba255(255, 255, 0, 255))
+            self.channels_to_mask.append(len(self.channel_names) - 1)
 
         if self.row[DataField.NucleusContourReadPath] is None:
             self.row[DataField.NucleusContourReadPath] = self.row[
@@ -516,14 +519,20 @@ class ImageProcessor:
             ]
 
         # nucleus contour segmentation (good for viz in the volume viewer)
-        nuc_con_file = utils.normalize_path(self.row[DataField.NucleusContourReadPath])
-        # print(nuc_seg_file)
-        file_list.append(
-            (nuc_con_file, self.row[DataField.NucleusContourChannelIndex], "CON_DNA")
-        )
-        self.channel_names.append("CON_DNA")
-        self.channel_colors.append(_rgba255(0, 255, 255, 255))
-        self.channels_to_mask.append(len(self.channel_names) - 1)
+        readpath = self.row[DataField.NucleusContourReadPath]
+        if readpath != "" and readpath is not None:
+            nuc_con_file = utils.normalize_path(readpath)
+            # print(nuc_seg_file)
+            file_list.append(
+                (
+                    nuc_con_file,
+                    self.row[DataField.NucleusContourChannelIndex],
+                    "CON_DNA",
+                )
+            )
+            self.channel_names.append("CON_DNA")
+            self.channel_colors.append(_rgba255(0, 255, 255, 255))
+            self.channels_to_mask.append(len(self.channel_names) - 1)
 
         return file_list
 
@@ -600,9 +609,9 @@ class ImageProcessor:
             channel.id = f"Channel:0:{c}"
 
         # 2. remove all planes whose C index is not in self.channel_indices
-        for p in pix.planes:
-            if p.the_c not in self.channel_indices:
-                pix.planes.remove(p)
+        new_planes = [p for p in pix.planes if p.the_c in self.channel_indices]
+        # new_planes = filter(lambda p: p.the_c in self.channel_indices, pix.planes)
+        pix.planes = new_planes
 
         # 3. then remap the C of the remaining planes, as they stll have their old channel indices
         for p in pix.planes:

--- a/cellbrowser_tools/jobScheduler.py
+++ b/cellbrowser_tools/jobScheduler.py
@@ -1,3 +1,4 @@
+from cellbrowser_tools.dataset_constants import SLURM_OUTPUT_DIR, SLURM_ERROR_DIR
 import subprocess
 import os
 import random
@@ -7,7 +8,16 @@ import jinja2
 
 
 def _job_prefs_from_prefs(prefs, name, array=False):
-    job_prefs = prefs["job_prefs"].copy()
+    job_prefs = {
+        "max_simultaneous_jobs": 100,
+        "partition": "aics_cpu_general",
+        "time": "06:00:00",
+        "cpus-per-task": 1,
+        "mem-per-cpu": "16G",
+        "output": SLURM_OUTPUT_DIR,
+        "error": SLURM_ERROR_DIR
+    }
+    # job_prefs = prefs["job_prefs"].copy()
     arraystring = f"_%A_%a" if array else f"_%A"
     job_prefs["output"] = os.path.join(
         prefs["sbatch_output"], name + arraystring + ".out"

--- a/cellbrowser_tools/jobScheduler.py
+++ b/cellbrowser_tools/jobScheduler.py
@@ -15,7 +15,7 @@ def _job_prefs_from_prefs(prefs, name, array=False):
         "cpus-per-task": 1,
         "mem-per-cpu": "16G",
         "output": SLURM_OUTPUT_DIR,
-        "error": SLURM_ERROR_DIR
+        "error": SLURM_ERROR_DIR,
     }
     # job_prefs = prefs["job_prefs"].copy()
     arraystring = f"_%A_%a" if array else f"_%A"
@@ -82,7 +82,7 @@ def submit_one(commandstring, prefs, name="", do_run=True, deps=[], mem=""):
         slurm_args.append(f"--{keyword} {value}")
 
     batchrunnerscriptname = f"BatchRunner{name}_{unique_id}.sh"
-    script = Path(prefs["out_status"]) / batchrunnerscriptname
+    script = Path(prefs["status_dir"]) / batchrunnerscriptname
 
     config = {
         "job_with_args": commandstring,
@@ -134,8 +134,8 @@ def submit_batch(commandlist, prefs, name="", do_run=True, deps=[]):
 
         batchrunnerscriptname = f"BatchRunner{i}{name}_{unique_id}.sh"
         batchdatafilename = f"BatchData{i}{name}_{unique_id}.txt"
-        script = Path(prefs["out_status"]) / batchrunnerscriptname
-        batchfile = Path(prefs["out_status"]) / batchdatafilename
+        script = Path(prefs["status_dir"]) / batchrunnerscriptname
+        batchfile = Path(prefs["status_dir"]) / batchdatafilename
 
         config = {
             "mybatchdatafilename": batchfile,

--- a/cellbrowser_tools/validateProcessedImages.py
+++ b/cellbrowser_tools/validateProcessedImages.py
@@ -442,7 +442,7 @@ def build_cfe_dataset_2020(prefs):
         dataset.append(
             {
                 "file_info": {x: rowdict[x] for x in rowdict if x in file_info_columns},
-                "measured_features": {
+                "features": {
                     x: rowdict[x] for x in rowdict if x not in file_info_columns
                 },
             }

--- a/preferences.json
+++ b/preferences.json
@@ -1,8 +1,0 @@
-{
-	"queue_name": "aics_assay_dev",
-	"njobs": "300",
-	"walltime": "02:00:00",
-	"memory": "4gb",
-	"script_dir": ".",
-	"debug": "false"
-}

--- a/prefs.json
+++ b/prefs.json
@@ -1,16 +1,5 @@
 {
   "out_status": "//allen/aics/animated-cell/Dan/cellbrowser-tools/processing/dataset_2_test",
   "out_dir": "//allen/aics/animated-cell/Allen-Cell-Explorer/Allen-Cell-Explorer_2_test",
-
-  "script_dir": "scripts_slurm",
-  "data_log_name": "data_jobs_out.csv",
-  "job_prefs": {
-    "max_simultaneous_jobs": 100,
-    "partition": "aics_cpu_general",
-    "time": "06:00:00",
-    "cpus-per-task": 1,
-    "mem-per-cpu": "16G",
-    "output": "out/",
-    "error": "err/"
-  }
+  "data_log_name": "data_jobs_out.csv"
 }

--- a/prefs.json
+++ b/prefs.json
@@ -1,5 +1,4 @@
 {
   "out_status": "//allen/aics/animated-cell/Dan/cellbrowser-tools/processing/dataset_2_test",
-  "out_dir": "//allen/aics/animated-cell/Allen-Cell-Explorer/Allen-Cell-Explorer_2_test",
-  "data_log_name": "data_jobs_out.csv"
+  "out_dir": "//allen/aics/animated-cell/Allen-Cell-Explorer/Allen-Cell-Explorer_2_test"
 }

--- a/prefs_dev.json
+++ b/prefs_dev.json
@@ -1,15 +1,5 @@
 {
   "out_status": "//allen/aics/animated-cell/Dan/cellbrowser-tools/processing",
   "out_dir": "//allen/aics/animated-cell/Dan/cellbrowser-tools/dataset",
-
-  "script_dir": "scripts_slurm",
-  "data_log_name": "data_jobs_out.csv",
-  "job_prefs": {
-    "max_simultaneous_jobs": 100,
-    "partition": "aics_cpu_general",
-    "time": "03:00:00",
-    "cpus-per-task": 1,
-    "output": "out/",
-    "error": "err/"
-  }
+  "data_log_name": "data_jobs_out.csv"
 }

--- a/prefs_dev.json
+++ b/prefs_dev.json
@@ -1,5 +1,4 @@
 {
   "out_status": "//allen/aics/animated-cell/Dan/cellbrowser-tools/processing",
-  "out_dir": "//allen/aics/animated-cell/Dan/cellbrowser-tools/dataset",
-  "data_log_name": "data_jobs_out.csv"
+  "out_dir": "//allen/aics/animated-cell/Dan/cellbrowser-tools/dataset"
 }

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "console_scripts": [
             "build_release=cellbrowser_tools.bin.build_release:main",
             "make_images=cellbrowser_tools.bin.make_images:main",
+            "make_downloader_manifest=cellbrowser_tools.bin.make_downloader_manifest:main",
             "processImageWithSegmentation=cellbrowser_tools.bin.processImageWithSegmentation:main",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ requirements = [
     "labkey",
     "lkaccess>=1.4.21",
     "ome-types>=0.2.3",
-    "pandas==1.0.3",
+    "pandas",
     "prefect==0.9.7",
     "quilt3",
     "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
     entry_points={
         "console_scripts": [
             "build_release=cellbrowser_tools.bin.build_release:main",
+            "make_images=cellbrowser_tools.bin.make_images:main",
             "processImageWithSegmentation=cellbrowser_tools.bin.processImageWithSegmentation:main",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ requirements = [
     "prefect==0.9.7",
     "quilt3",
     "jinja2",
-    "urllib3==1.26.5",  # quilt3
+    "urllib3",  # quilt3
     "python-dateutil==2.8.0",  # quilt3
     "cloudpickle==1.3.0",  # prefect
 ]


### PR DESCRIPTION
Lots of changes to process the cellsystems cardio fish datasets for Cell Feature Explorer.

1. Inspired by the structure of Sylvain's post acquisition pipeline scripts, I added a new bin script (`bin/make_images.py`) to process volume images only, using command line args.  Script will write output images to a designated output dir and email me when it's done.  Script still requires an input manifest similar to that of the variance dataset. (Future: reduce this input manifest to a minimal set of required data fields)
2. Added a very simple bin script to prepare the manifest file format that Gabe's downloader requires (`bin/make_downloader_manifest.py`).  This script adds no extra "metadata" at this time.
3. A lot of refactoring of args so that `make_images.py` can reuse a lot of the underlying processing code.
4. Some special case code for the cellsystems cardio FISH dataset that shows the need for better data-driven specification of image channel semantics. 

